### PR TITLE
Add a template for front page

### DIFF
--- a/js/components/App.jsx
+++ b/js/components/App.jsx
@@ -23,7 +23,7 @@ module.exports = React.createClass({
 						component="div" transitionName={this.props.router.location.action === 'POP' ? 'card-back' : 'card' }
 						transitionEnterTimeout={500} transitionLeaveTimeout={500}
 						>
-						<div className="page-transition">{this.props.children || <Intro />}</div>
+						<div className="page-transition">{this.props.children}</div>
 					</RouteCSSTransition>
 				</div>
 				<APIConsole onExpand={this.handleToggleExpandConsole} isExpanded={this.props.display.consoleExpanded} />

--- a/js/components/pages/Home.jsx
+++ b/js/components/pages/Home.jsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { findWhere } from 'underscore'
+import { fetchPageBySlug } from '../../actions'
+import Text from '../modules/Text'
+import Image from '../modules/Image'
+import Blockquote from '../modules/Blockquote'
+import Header from '../modules/Header'
+import Map from '../modules/Map'
+import TwitterTimeline from '../modules/TwitterTimeline'
+
+module.exports = React.createClass({
+
+	componentDidMount: function() {
+		this.props.dispatch( fetchPageBySlug( 'index' ) )
+	},
+
+	render: function() {
+		var page = findWhere( this.props.posts.pages, { slug: 'index' } )
+
+		if ( ! page ) {
+			return (
+					<div className="loading-wrap">
+						<div className="loading"><span className="fa fa-heart"></span> LOADING</div>
+					</div>
+			)
+		}
+
+		return (
+				<div className="Posts">
+					<div className="Post">
+						<h1>{page.title.rendered}</h1>
+						{page.page_builder.modules.map( Module => {
+								switch ( Module.type ) {
+										case 'text':
+												return <Text {...Module.data} />
+										case 'blockquote':
+												return <Blockquote {...Module.data} />
+										case 'image':
+												return <Image {...Module.data} />
+										case 'header':
+												return <Header {...Module.data} />
+										case 'map':
+												return <Map {...Module.data} />
+										case 'twitter_timeline':
+												return <TwitterTimeline {...Module.data} />
+										}
+								return <div></div>
+								})}
+					</div>
+				</div>
+		)
+	}
+})

--- a/js/index.js
+++ b/js/index.js
@@ -17,6 +17,7 @@ import Sponsors from './components/pages/Sponsors'
 import Posts from './components/pages/Posts'
 import Page from './components/pages/Page'
 import Post from './components/pages/Post'
+import Home from './components/pages/Home'
 
 var logger = createLogger({
 	level: 'info',
@@ -35,7 +36,7 @@ const routes = (
 			<Route path="sponsors" component={connect(state=>state)(Sponsors)} />
 			<Route path="news" component={connect(state=>state)(Posts)} />
 			<Route path="news/:slug" component={connect(state=>state)(Post)} />
-			<Route path="" component={Intro} />
+			<Route path="" component={connect(state=>state)(Home)} />
 		</Route>
 	</ReduxRouter>
 );


### PR DESCRIPTION
Ok, maybe this is stupid, but I thought I could add a template for the home page so we can use the page builder for the Intro section and the sponsor logos.
Locally I added each sponsor logo as an image module on the page that is set as the "Front Page" in the reading settings.
I am following the assumption that the slug is `index` which is what is displayed when you remove the reading setting.
There are no JS errors, just shows an empty page ( not blank )
