### PR TITLE
Add the second level toolbar to pages

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -57,6 +57,11 @@ add_filter( 'pre_option_permalink_structure', function() {
 
 add_filter( 'qm/dispatch/html', '__return_false' );
 
+add_filter( 'mpb_wysiwyg_args', function( $args ) {
+	$args['teeny'] = false;
+	return $args;
+} );
+
 /**
  * Send preview data instead.
  */


### PR DESCRIPTION
Can we please get the second level of the editor toolbar added to pages to easily add headers and format content. 

We only have the first level here:

<img width="817" alt="screenshot 2015-11-09 10 59 14" src="https://cloud.githubusercontent.com/assets/1880844/11029654/18eeaafa-86d1-11e5-80c5-631febddac3b.png">
