### PR TITLE
eliminates flash of content during page transition

### DIFF
--- a/sass/main.sass
+++ b/sass/main.sass
@@ -149,7 +149,7 @@ iframe
 	transform: translate3d(0,0,0)
 	top: 0
 	left: 0
-	opacity: 1
+	opacity: 0
 	width: 100%
 
 	&.card-leave-active


### PR DESCRIPTION
Was playing around with this and made this change locally.  It's not visible on every page...it seems to be most apparent when clicking from the home page.
