### PR TITLE
Speakers overview

### DIFF
--- a/assets/sass/_settings.scss
+++ b/assets/sass/_settings.scss
@@ -210,39 +210,44 @@ a img.aligncenter {
 }
 
 .wp-caption {
-	background: #fff;
-	border: 1px solid #f0f0f0;
-	max-width: 96%; /* Image does not overflow the content area */
-	padding: 5px 3px 10px;
-	text-align: center;
-}
-
-.wp-caption.alignnone {
-	margin: 5px rem(24) rem(24) 0;
-}
-
-.wp-caption.alignleft {
-	margin: 5px rem(48) rem(24) 0;
-}
-
-.wp-caption.alignright {
-	margin: 5px 0 rem(24) rem(48);
-}
-
-.wp-caption img {
-	border: 0 none;
-	height: auto;
-	margin: 0;
-	max-width: 98.5%;
+	background: transparent;
+	border: 0;
+	max-width: 99%; /* Image does not overflow the content area */
 	padding: 0;
-	width: auto;
-}
+	text-align: center;
 
-.wp-caption p.wp-caption-text {
-	font-size: 11px;
-	line-height: 17px;
-	margin: 0;
-	padding: 0 4px 5px;
+	&.aligncenter,
+	&.alignnone {
+		margin: rem(24) 0 rem(24) 0;
+	}
+
+	&.alignleft {
+		margin: 5px rem(48) rem(24) 0;
+	}
+
+	&.alignright {
+		margin: 5px 0 rem(24) rem(48);
+	}
+
+	img {
+		border: 0 none;
+		height: auto;
+		margin: 0;
+		padding: 0;
+		width: 100%;
+	}
+
+	p {
+		margin: 0;
+	}
+
+	p.wp-caption-text {
+		color: #7c7c7c;
+		font-size: rem(12);
+		line-height: 1.2;
+		margin: 0;
+		padding: 10px 0 10px;
+	}
 }
 
 /* Text meant only for screen readers. */

--- a/assets/sass/components/Post.scss
+++ b/assets/sass/components/Post.scss
@@ -23,6 +23,9 @@
 	img {
 		margin: 15px auto;
 	}
+	.wp-caption img {
+		margin-bottom: 0;
+	}
 	.alignnone {
 		margin-left: 0;
 		margin-right: 0;
@@ -35,17 +38,3 @@
 	}
 }
 
-.wp-caption {
-	width: auto !important;
-	margin: 15px 0 30px;
-	img {
-		display: block;
-		margin: 0;
-	}
-	p {
-		margin: 5px 0 0;
-		color: darken($ador-grey, 30%);
-		font-size: $h6-font-size;
-		font-style: italic;
-	}
-}

--- a/assets/sass/components/Speakers.scss
+++ b/assets/sass/components/Speakers.scss
@@ -19,25 +19,21 @@
 }
 
 .SpeakerList {
-	@include display(flex);
 	@include align-items(center);
-	@include justify-content(center);
+	@include display(flex);
 	@include flex-flow(row wrap);
+	@include justify-content(center);
 	padding: 0;
 	text-align: center;
 
 	.speaker {
-		@include display(flex);
-		@include align-items(flex-end);
-		@include justify-content(center);
-		width: 20%;
 		background: $ador-d-blue;
-		min-height: 210px;
-		font-size: 24px;
 		font-family: $f_sans;
-		text-transform: uppercase;
+		font-size: 24px;
 		font-weight: bold;
-		padding-bottom: 1rem;
+		min-height: 210px;
+		text-transform: uppercase;
+		width: 20%;
 
 		@media #{$tablet_mq} {
 			width: 50%;
@@ -51,6 +47,36 @@
 
 		& + .speaker {
 			@include ador-background-image('assets/images/ador-poststatus-12.jpg');
+		}
+
+		&:hover {
+			text-decoration: none;
+		}
+
+		.speaker_hover {
+			@include display(flex);
+			@include align-items(flex-end);
+			@include justify-content(center);
+			height: 100%;
+			min-height: 210px; // same as min-height of .speaker
+			margin: 0;
+
+			&:hover{
+				background-color: rgba(34, 48, 63, 0.6);
+			}
+		}
+
+		.textcontainer {
+			text-align: center;
+			margin: 0;
+			padding-bottom: 1rem;
+			width: 100%;
+		}
+
+		span {
+			display: block;
+			width: 100%;
+			color: $ador-orange;
 		}
 
 		.company {

--- a/js/components/modules/SpeakersOverview.jsx
+++ b/js/components/modules/SpeakersOverview.jsx
@@ -23,19 +23,23 @@ module.exports = React.createClass( {
 		return (
 			<section className="Speakers">
 				{ this.props.heading && <Header {...this.props} /> }
-				<ul className="SpeakerList">
+				<div className="SpeakerList">
 					{this.props.posts.speakers.map( speaker => {
 						var attr = {key: speaker.id}
 						if ( speaker._embedded && speaker._embedded['wp:featuredmedia'] ) {
 							attr.style = {backgroundImage: 'url(' + speaker._embedded['wp:featuredmedia'][0].source_url + ')'}
 						}
-						return <li className="speaker" {...attr}>
-							<Link to={'/speakers/' + speaker.id}>
-								{speaker.title.rendered}<span className="company">{speaker.company}</span>
+						return <Link to={'/speakers/' + speaker.id} className="speaker" {...attr}>
+								<div className="speaker_hover">
+									<p className="textcontainer">
+										<span className="name">{speaker.title.rendered}</span>
+										<span className="company">{speaker.company}</span>
+									</p>
+								</div>
 							</Link>
-						</li>
+
 					} )}
-				</ul>
+				</div>
 			</section>
 		)
 	}

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/humanmade/feelingrestful-theme
 Author: Human Made Limited
 Author URI: http://hmn.md/
 Description: A updated version of Feeling RESTful Theme, for the A Day of Rest Boston Event.
-Version: 2.0.0
+Version: 2.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: feelingrestful-theme


### PR DESCRIPTION
- Adding in wp-caption styling as requested in https://github.com/humanmade/feelingrestful/issues/286 
- Styled up speaker overview  so that the whole block is a link
- Removed lines from under speakers name
- Added overlay on hover so you knwo where you are
- Remembered to update version number 
